### PR TITLE
Switch to ajv. Looks promising.

### DIFF
--- a/nbformat.js
+++ b/nbformat.js
@@ -1,13 +1,13 @@
-var Validator = require('jsonschema').Validator;
+var Ajv = require('ajv');
 var v3Schema = require('./v3/nbformat.v3.schema.json');
 var v4Schema = require('./v4/nbformat.v4.schema.json');
 
 function NotebookValidator() {
-    Validator.call(this);
+    Ajv.call(this);
     this.addSchema(v3Schema, '/v3');
     this.addSchema(v4Schema, '/v4');
 }
-NotebookValidator.prototype = Object.create(Validator.prototype);
+NotebookValidator.prototype = Object.create(Ajv.prototype);
 
 
 /**
@@ -16,7 +16,7 @@ NotebookValidator.prototype = Object.create(Validator.prototype);
  * @return {bool}            Validity
  */
 NotebookValidator.prototype.validateNotebook = function (notebook) {
-    return this.validate(notebook, '/v' + notebook.nbformat);
+    return this.validate('/v' + notebook.nbformat, notebook);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/rgbkrk/nbformatjs#readme",
   "dependencies": {
-    "jsonschema": "^1.0.2"
+    "ajv": "^0.6.13"
   }
 }


### PR DESCRIPTION
https://github.com/ebdrup/json-schema-benchmark

```
> NotebookValidator = require('./nbformat');
> nbv = new NotebookValidator();
> var fs = require('fs');
> var nb = "tests/test4.ipynb";
> var nbModel = JSON.parse(fs.readFileSync(nb, 'utf8'))
> nbv.validateNotebook(nbModel)
true
> nbModel = JSON.parse(fs.readFileSync("tests/invalid.ipynb", 'utf8'));
> nbv.validateNotebook(nbModel)
false
> nbv.errors
[ { keyword: 'oneOf',
    dataPath: '.cells[0]',
    message: 'should match exactly one schema in oneOf' } ]
```

Actually, the output in #1 is much better for errors. `ajv` is faster though.
